### PR TITLE
Deprecate `TestrailProject#get_plans`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 * `TestrailRun#is_completed` accessor to check for closed runs
 * `TestrailProject#suites` to get list of Suites
 * `TestrailProject#runs` to get list of Runs
+* `TestrailProject#plans` to get list of Plans
 
 ### Changes
 
 * Do not send `codecov` info on non-CI runs
 * Deprecate `TestrailProject#get_suites`
 * Deprecate `TestrailProject#get_runs`
+* Deprecate `TestrailProject#get_plans`
 * Minor refactor with module extraction
 
 ## 0.1.0 (2020-11-27)

--- a/lib/onlyoffice_testrail_wrapper/testrail_project/testrail_project_plan_helper.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_project/testrail_project_plan_helper.rb
@@ -38,13 +38,26 @@ module OnlyofficeTestrailWrapper
 
     # Get list of all TestPlans
     # @param filters [Hash] filter conditions
-    # @return [Array, TestrailPlan] test plans
+    # @return [Array<Hash>] test plans
     def get_plans(filters = {})
       get_url = "index.php?/api/v2/get_plans/#{@id}"
       filters.each { |key, value| get_url += "&#{key}=#{value}" }
       plans = Testrail2.http_get(get_url)
       @plans_names = HashHelper.get_hash_from_array_with_two_parameters(plans, 'name', 'id') if @plans_names.empty?
       plans
+    end
+
+    extend Gem::Deprecate
+    deprecate :get_plans, 'plans', 2069, 1
+
+    # Get list of all TestPlans
+    # @param filters [Hash] filter conditions
+    # @return [Array<TestrailPlan>] test plans
+    def plans(filters = {})
+      get_url = "index.php?/api/v2/get_plans/#{@id}"
+      filters.each { |key, value| get_url += "&#{key}=#{value}" }
+      plans = Testrail2.http_get(get_url)
+      plans.map { |suite| HashHelper.parse_to_class_variable(suite, TestrailPlan) }
     end
 
     # @param [String] name of test plan

--- a/spec/onlyoffice_testrail_wrapper/testrail2_project_spec.rb
+++ b/spec/onlyoffice_testrail_wrapper/testrail2_project_spec.rb
@@ -29,4 +29,12 @@ describe OnlyofficeTestrailWrapper::Testrail2, '#project' do
   it '#runs return list of TestrailRun objects' do
     expect(project.runs.first).to be_a(OnlyofficeTestrailWrapper::TestrailRun)
   end
+
+  it '#get_plans return list of hashes' do
+    expect(project.get_plans.first).to be_a(Hash)
+  end
+
+  it '#runs return list of TestrailPlan objects' do
+    expect(project.plans.first).to be_a(OnlyofficeTestrailWrapper::TestrailPlan)
+  end
 end


### PR DESCRIPTION
Use `TestrailProject#plans` to get list of Plans