### PR TITLE
Deprecate `TestrailProject#get_plan_by_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `TestrailProject#suites` to get list of Suites
 * `TestrailProject#runs` to get list of Runs
 * `TestrailProject#plans` to get list of Plans
+* `TestrailProject#plan_by_name` to get plan by name
 
 ### Changes
 
@@ -16,6 +17,7 @@
 * Deprecate `TestrailProject#get_suites`
 * Deprecate `TestrailProject#get_runs`
 * Deprecate `TestrailProject#get_plans`
+* Deprecate `TestrailProject#get_plan_by_name`
 * Minor refactor with module extraction
 
 ## 0.1.0 (2020-11-27)

--- a/lib/onlyoffice_testrail_wrapper/testrail_plan.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_plan.rb
@@ -41,6 +41,8 @@ module OnlyofficeTestrailWrapper
       Testrail2.http_post "index.php?/api/v2/delete_plan_entry/#{@id}/#{entry_id}", {}
     end
 
+    # Delete current plan
+    # @return [nil]
     def delete
       Testrail2.http_post "index.php?/api/v2/delete_plan/#{@id}", {}
       OnlyofficeLoggerHelper.log "Deleted plan: #{@name}"

--- a/lib/onlyoffice_testrail_wrapper/testrail_project/testrail_project_plan_helper.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_project/testrail_project_plan_helper.rb
@@ -36,6 +36,18 @@ module OnlyofficeTestrailWrapper
       @plans_names[StringHelper.warnstrip!(name.to_s)].nil? ? nil : get_plan_by_id(@plans_names[name])
     end
 
+    extend Gem::Deprecate
+    deprecate :get_plan_by_name, 'plan_by_name', 2069, 1
+
+    # @param [String] name of plan
+    # @return [TestrailPlan, nil] result of plan search
+    def plan_by_name(name)
+      result = plans.select { |plan| plan.name == name }
+      return nil if result.empty?
+
+      result
+    end
+
     # Get list of all TestPlans
     # @param filters [Hash] filter conditions
     # @return [Array<Hash>] test plans

--- a/spec/onlyoffice_testrail_wrapper/testrail2_plan_spec.rb
+++ b/spec/onlyoffice_testrail_wrapper/testrail2_plan_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OnlyofficeTestrailWrapper::Testrail2, '#plan' do
+  let(:project) { described_class.new.project('onlyoffice_testrail_wrapper ci tests') }
+  let(:plan_name) { "Plan_#{SecureRandom.uuid}" }
+
+  it 'Plan can be created' do
+    plan = project.create_new_plan(plan_name)
+    expect(project.plan_by_name(plan_name)).not_to be_nil
+    plan.delete
+  end
+
+  it 'Plan can be deleted' do
+    plan = project.create_new_plan(plan_name)
+    plan.delete
+    expect(project.plan_by_name(plan_name)).to be_nil
+  end
+end


### PR DESCRIPTION
Use `TestrailProject#plan_by_name` to get plan by name