### PR TITLE
Disable parallel run in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,6 +11,7 @@ jobs:
         include:
           - ruby: head
             allow-failures: true
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Remove unused `TestrailTools.close_run`
 * Remove unused `TestrailTools.get_incompleted_plan_entries`
 * Cleanup test runs and plans after spec run
+* Disable parallel run in CI
 
 ## 0.1.0 (2020-11-27)
 


### PR DESCRIPTION
Some tests are failing in random with parallel run
Tried to reproduce those failure on local machine
with single thread run - no success

So I'm trying to disable parallel run for all CI tests